### PR TITLE
Support F609 different header

### DIFF
--- a/zcu/zte.py
+++ b/zcu/zte.py
@@ -59,7 +59,7 @@ def add_header(payload, signature, payload_type, version):
 
     payload_data = payload.read()
     # check if model is F609
-    if signature is not b'F609':
+    if signature != b'F609':
         if payload_type == 2:
             full_payload_length = len(payload_data)
             if signature_length > 0:

--- a/zcu/zte.py
+++ b/zcu/zte.py
@@ -58,20 +58,21 @@ def add_header(payload, signature, payload_type, version):
     signature_length = len(signature)
 
     payload_data = payload.read()
-
-    if payload_type == 2:
-        full_payload_length = len(payload_data)
-        if signature_length > 0:
-            full_payload_length += 12 + signature_length
-        full_payload.write(struct.pack('>4I', *constants.ZTE_MAGIC))
-        full_payload.write(struct.pack('>28I', *(0, 0, 4, 0,
-                                                 0, 0, 0, 0,
-                                                 0, 0, 0, 64,
-                                                 version, 128,
-                                                 full_payload_length, 0,
-                                                 0, 0, 0, 0,
-                                                 0, 0, 0, 0,
-                                                 0, 0, 0, 0)))
+    # check if model is F609
+    if signature is not b'F609':
+        if payload_type == 2:
+            full_payload_length = len(payload_data)
+            if signature_length > 0:
+                full_payload_length += 12 + signature_length
+            full_payload.write(struct.pack('>4I', *constants.ZTE_MAGIC))
+            full_payload.write(struct.pack('>28I', *(0, 0, 4, 0,
+                                                     0, 0, 0, 0,
+                                                     0, 0, 0, 64,
+                                                     version, 128,
+                                                     full_payload_length, 0,
+                                                     0, 0, 0, 0,
+                                                     0, 0, 0, 0,
+                                                     0, 0, 0, 0)))
     if signature_length > 0:
         full_payload.write(struct.pack('>3I', *(constants.SIGNATURE_MAGIC,
                                                 0,


### PR DESCRIPTION
I can decode with type-0 and  type-0 creates a header that almost match the original, though encoding with type-0 makes the payload different. I am using these arguments to encode the config:
`--signature F609 --payload-type 2 --include-unencrypted-length --version 1 decoded.xml encoded.bin`
Using `payload-type 2` works and the payload are perfect, though it 128 first bytes which are not required.
I can provide the original header if required.
Right now I am not sure if any other model have the same header as the F609.
I modified the payload type check to skip if signature is `F609`