### PR TITLE
Add support for ZXHN H268Q V7.0 which requires fixed suffix instead of prefix

### DIFF
--- a/examples/decode.py
+++ b/examples/decode.py
@@ -27,6 +27,10 @@ def main():
                         help="Override key prefix for Type 4 devices")
     parser.add_argument("--iv-prefix", type=str, default="",
                         help="Override iv prefix for Type 4 devices")
+    parser.add_argument("--key-suffix", type=str, default="",
+                        help="Override key suffix for Type 4 devices")
+    parser.add_argument("--iv-suffix", type=str, default="",
+                        help="Override iv suffix for Type 4 devices")
     args = parser.parse_args()
 
     # TODO: can this be handled differently?
@@ -96,8 +100,34 @@ def main():
                         # remove all spaces
                         key = signature.replace(" ", "")
                         signature_is_key = True
-                        decryptor = T4Xcryptor(key)
                         print("Using signature: %s" % key)
+                        use_key_prefix = None
+                        use_iv_prefix = None
+                        use_key_suffix = None
+                        use_iv_suffix = None
+                        if args.key_prefix:
+                            if args.key_prefix == "NONE":
+                                use_key_prefix = ""
+                            else:
+                                use_key_prefix = args.key_prefix
+
+                            print("Using key prefix: %s" % use_key_prefix)
+                        if args.iv_prefix:
+                            if args.iv_prefix == "NONE":
+                                use_iv_prefix = ""
+                            else:
+                                use_iv_prefix = args.iv_prefix
+
+                            print("Using iv prefix: %s" % use_iv_prefix)
+                        if args.key_suffix:
+                            use_key_suffix = args.key_suffix
+                            print("Using key suffix: %s" % use_key_suffix)
+                        if args.iv_suffix:
+                            use_iv_suffix = args.iv_suffix
+                            print("Using iv suffix: %s" % use_iv_suffix)
+
+                        decryptor = T4Xcryptor(key, key_prefix=use_key_prefix, iv_prefix=use_iv_prefix, key_suffix=use_key_suffix, iv_suffix=use_iv_suffix)
+
                 infile_dec = decryptor.decrypt(infile)
 
                 if zcu.zte.read_payload_type(infile_dec, raise_on_error=False) is None and payload_type == 4 and not signature_is_key:

--- a/examples/encode.py
+++ b/examples/encode.py
@@ -30,6 +30,14 @@ def main():
                         help='payload version (1=unknown, 2=unknown)')
     parser.add_argument('--include-unencrypted-length', action='store_true',
                         help='Include unencrypted length in header (default No)')
+    parser.add_argument("--key-prefix", type=str, default="",
+                        help="Override key prefix for Type 4 devices")
+    parser.add_argument("--iv-prefix", type=str, default="",
+                        help="Override iv prefix for Type 4 devices")
+    parser.add_argument("--key-suffix", type=str, default="",
+                        help="Override key suffix for Type 4 devices")
+    parser.add_argument("--iv-suffix", type=str, default="",
+                        help="Override iv suffix for Type 4 devices")
 
     args = parser.parse_args()
 
@@ -41,7 +49,32 @@ def main():
         payload_type = 4
     elif args.signature_encryption:
         key = args.signature_encryption
-        encryptor = T4Xcryptor(key, chunk_size=args.chunk_size, include_unencrypted_length=args.include_unencrypted_length)
+        use_key_prefix = None
+        use_iv_prefix = None
+        use_key_suffix = None
+        use_iv_suffix = None
+        if args.key_prefix:
+            if args.key_prefix == "NONE":
+                use_key_prefix = ""
+            else:
+                use_key_prefix = args.key_prefix
+
+            print("Using key prefix: %s" % use_key_prefix)
+        if args.iv_prefix:
+            if args.iv_prefix == "NONE":
+                use_iv_prefix = ""
+            else:
+                use_iv_prefix = args.iv_prefix
+
+            print("Using iv prefix: %s" % use_iv_prefix)
+        if args.key_suffix:
+            use_key_suffix = args.key_suffix
+            print("Using key suffix: %s" % use_key_suffix)
+        if args.iv_suffix:
+            use_iv_suffix = args.iv_suffix
+            print("Using iv suffix: %s" % use_iv_suffix)
+        encryptor = T4Xcryptor(key, chunk_size=args.chunk_size, include_unencrypted_length=args.include_unencrypted_length,
+                               key_prefix=use_key_prefix, iv_prefix=use_iv_prefix, key_suffix=use_key_suffix, iv_suffix=use_iv_suffix)
         payload_type = 4
     else:
         key = args.key.ljust(16, b'\0')[:16]

--- a/zcu/xcryptors.py
+++ b/zcu/xcryptors.py
@@ -14,14 +14,19 @@ class Xcryptor():
 
     default_key_prefix = None
     default_iv_prefix = None
+    default_key_suffix = None
+    default_iv_suffix = None
 
     def __init__(self, aes_key, chunk_size=65536, include_unencrypted_length=False,
-                 key_prefix=None, iv_prefix=None):
+                 key_prefix=None, iv_prefix=None,
+                 key_suffix=None, iv_suffix=None):
         self.chunk_size = chunk_size
         self.include_unencrypted_length = include_unencrypted_length
         # currently unsupported / unused in Xcryptor
-        self.key_prefix = key_prefix if key_prefix else self.default_key_prefix
-        self.iv_prefix = iv_prefix if iv_prefix else self.default_iv_prefix
+        self.key_prefix = key_prefix if key_prefix is not None else self.default_key_prefix
+        self.iv_prefix = iv_prefix if iv_prefix is not None else self.default_iv_prefix
+        self.key_suffix = key_suffix if key_suffix is not None else self.default_key_suffix
+        self.iv_suffix = iv_suffix if iv_suffix is not None else self.default_iv_suffix
 
         self.set_key(aes_key)
 
@@ -33,6 +38,12 @@ class Xcryptor():
 
     def set_key_prefix(self, key_prefix):
         raise Exception("Base Xcryptor does not support 'key_prefix'")
+
+    def set_iv_suffix(self, iv_suffix):
+        raise Exception("Base Xcryptor does not support 'iv_suffix'")
+
+    def set_key_suffix(self, key_suffix):
+        raise Exception("Base Xcryptor does not support 'key_suffix'")
 
     def read_chunks(self, infile):
         """decrypt a block
@@ -128,6 +139,8 @@ class T4Xcryptor(Xcryptor):
     # type 4 encryption, using signature for key/iv
     default_key_prefix = "Key02721401"
     default_iv_prefix = "Iv02721401"
+    default_key_suffix = ""
+    default_iv_suffix = ""
 
     force_same_data_length = False
 
@@ -137,13 +150,19 @@ class T4Xcryptor(Xcryptor):
     def set_iv_prefix(self, iv_prefix):
         self.iv_prefix = iv_prefix
 
+    def set_key_suffix(self, key_suffix):
+        self.key_suffix = key_suffix
+
+    def set_iv_suffix(self, iv_suffix):
+        self.iv_suffix = iv_suffix
+
     def set_key(self, aes_key):
         if isinstance(aes_key, bytes):
             aes_key_str = aes_key.decode("utf8")
         else:
             aes_key_str = aes_key
-        plain_key = self.key_prefix + aes_key_str
-        plain_iv = self.iv_prefix + aes_key_str
+        plain_key = self.key_prefix + aes_key_str + self.key_suffix
+        plain_iv = self.iv_prefix + aes_key_str + self.iv_suffix
         key = sha256(plain_key.encode("utf8")).digest()
         iv = sha256(plain_iv.encode("utf8")).digest()
 


### PR DESCRIPTION
Add support for type4 signature crypt/decrypt that has the fixed part of the key/iv as a SUFFIX instead of PREFIX

Both versions of the ZXHN H268Q V7.0 firmware available to me do this to generate the config key:
AESKey = modelNameWithoutSpaces + "Key" + "02710010"
AESIV = modelNameWithoutSpaces + "Iv" + "02710010"
So the prefix options in existing zte-config-utility are not enough, as the fixed part needs to be after the "Signature"