### PR TITLE
Add H288A as a known model and it's signature-based keygen method

### DIFF
--- a/zcu/known_keys.py
+++ b/zcu/known_keys.py
@@ -30,7 +30,7 @@ def find_key(signature):
 def get_all_keys():
     return KNOWN_KEYS.keys()
 
-KNOWN_MODELS = ["H268Q", "H298Q"]
+KNOWN_MODELS = ["H268Q", "H298Q", "H288A"]
 
 def get_all_models():
     return KNOWN_MODELS
@@ -66,7 +66,8 @@ def signature_keygen(params, key_suffix = 'Key02721401', iv_suffix = 'Iv02721401
 KNOWN_KEYGENS = {
     (lambda p : serial_keygen(p)): ["ZXHN H298A"],
     (lambda p : signature_keygen(p)): ["ZXHN H168N V3.5"],
-    (lambda p : signature_keygen(p, key_suffix='Key02710010', iv_suffix='Iv02710010')): ["ZXHN H298Q", "ZXHN H268Q"]
+    (lambda p : signature_keygen(p, key_suffix='Key02710010', iv_suffix='Iv02710010')): ["ZXHN H298Q", "ZXHN H268Q"],
+    (lambda p : signature_keygen(p, key_suffix='Key02710001', iv_suffix='Iv02710001')): ["H288A"]
 }
 
 def run_keygen(params):


### PR DESCRIPTION
Decrypts the "Wind" config.zip posted by @datio in https://github.com/mkst/zte-config-utility/issues/43
(`--signature H288A` must be passed to decode.py because that config.bin, for some reason, does not have a signature header)