### PR TITLE
Add support for H267A, Czech variant

### DIFF
--- a/tests/test_known_keys.py
+++ b/tests/test_known_keys.py
@@ -1,6 +1,6 @@
 import unittest
 from types import SimpleNamespace
-from zcu.known_keys import find_key, get_all_keys, run_keygen, run_all_keygens, mac_to_str
+from zcu.known_keys import find_key, get_all_keys, run_keygens, run_all_keygens, mac_to_str
 
 
 class TestPublicMethods(unittest.TestCase):
@@ -18,25 +18,25 @@ class TestPublicMethods(unittest.TestCase):
 
     def test_run_serial_keygen(self):
         params = SimpleNamespace(signature = "ZXHN H298A V1.0", serial = " HELLO")
-        res = run_keygen(params)
+        res = run_keygens(params)[0]
         self.assertEqual(res[0], "8cc72b05705d5c46 HELLO")
         self.assertEqual(res[1], "667b02a85c61c786 HELLO")
 
     def test_run_serial_keygen_custom(self):
         params = SimpleNamespace(signature = "ZXHN H298A V1.0", key_prefix = "HI", iv_prefix = "HELLO", serial = " THERE")
-        res = run_keygen(params)
+        res = run_keygens(params)[0]
         self.assertEqual(res[0], "HI THERE")
         self.assertEqual(res[1], "HELLO THERE")
 
     def test_run_signature_keygen_h168n(self):
         params = SimpleNamespace(signature = "ZXHN H168N V3.5")
-        res = run_keygen(params)
+        res = run_keygens(params)[0]
         self.assertEqual(res[0], "ZXHNH168NV3.5Key02721401")
         self.assertEqual(res[1], "ZXHNH168NV3.5Iv02721401")
 
     def test_run_signature_keygen_h268q(self):
         params = SimpleNamespace(signature = "ZXHN H268Q V7.0")
-        res = run_keygen(params)
+        res = run_keygens(params)[0]
         self.assertEqual(res[0], "ZXHNH268QV7.0Key02710010")
         self.assertEqual(res[1], "ZXHNH268QV7.0Iv02710010")
 

--- a/zcu/known_keys.py
+++ b/zcu/known_keys.py
@@ -92,16 +92,18 @@ def signature_keygen(params, key_suffix='Key02721401', iv_suffix='Iv02721401'):
 # 1st element is the function generating the key, 2nd is array of possible matching signature starts
 KNOWN_KEYGENS = {
     (lambda p : tagparams_keygen(p)): ["H288A"],
-    (lambda p : serial_keygen(p)): ["ZXHN H298A"],
+    (lambda p : serial_keygen(p)): ["ZXHN H298A", "ZXHN H267A V1.0"],
     (lambda p : signature_keygen(p)): ["ZXHN H168N V3.5"],
     (lambda p : signature_keygen(p, key_suffix='Key02710010', iv_suffix='Iv02710010')): ["ZXHN H298Q", "ZXHN H268Q"],
     (lambda p : signature_keygen(p, key_suffix='Key02710001', iv_suffix='Iv02710001')): ["H188A", "H288A"],
     (lambda p : signature_keygen(p, key_suffix='Key02660004', iv_suffix='Iv02660004')): ["H196Q"],
     (lambda p : signature_keygen(p, key_suffix='8cc72b05705d5c46f412af8cbed55aa', iv_suffix='667b02a85c61c786def4521b060265e')): ["ZXHN F450(EPON ONU)"],
+    (lambda p : ('8cc72b05705d5c46f412af8cbed55aad', '667b02a85c61c786def4521b060265e8', 'hardcoded key')): ['ZXHN H267A V1.0'],
 
 }
 
-def run_keygen(params):
+def run_keygens(params):
+    outArr = []
     for gen, sigs in KNOWN_KEYGENS.items():
         matching = False
         for sig in sigs:
@@ -111,8 +113,8 @@ def run_keygen(params):
         if matching:
             genResult = gen(params)
             if len(genResult):
-                return genResult
-    return None
+                outArr.append(genResult)
+    return outArr
 
 def run_all_keygens(params):
     outArr = []
@@ -124,9 +126,9 @@ def run_all_keygens(params):
     return outArr
 
 def run_any_keygen(params, wanted):
-    keygened = run_keygen(params)
-    if keygened is not None:
-        return keygened
+    keygened = run_keygens(params)
+    if keygened != []:
+        return keygened[0]
 
     #no match for signature found in keygens, find a generic keygen of wanted type and use that
     allgens = run_all_keygens(params)
@@ -136,3 +138,7 @@ def run_any_keygen(params, wanted):
 
     #should never get here as long as wanted is an existing type
     return None
+
+TYPE_3_KNOWN_KEY_IVS = [
+    ("H267AV1_CZkey", "H267AV1_CZIV", "H267A Czech")
+]


### PR DESCRIPTION
This adds two sets of hardcoded key and IV for the H267A, as sold by O2 in the Czech Republic.

Since there was already a H267A key listed, I had to also alter the code so it tries all matching keys for a model. I also added a list of keys with IVs for type-3 files.