### PR TITLE
Change output handling in examples

### DIFF
--- a/examples/auto.py
+++ b/examples/auto.py
@@ -317,14 +317,14 @@ def main():
     if outfile_path is None:
         outfile_path = infile_path.with_suffix(".xml")
 
-    if outfile_path.exists():
-        overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
-        while overwrite not in {"y", "n", ""}:
+        if outfile_path.exists():
             overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+            while overwrite not in {"y", "n", ""}:
+                overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
 
-        if overwrite != "y":
-            print("Not overwriting output, nothing to do!")
-            return
+            if overwrite != "y":
+                print("Not overwriting output, nothing to do!")
+                return
 
     infile = open(infile_path, "rb")
     outfile = open(outfile_path, "wb")

--- a/examples/auto.py
+++ b/examples/auto.py
@@ -317,6 +317,15 @@ def main():
     if outfile_path is None:
         outfile_path = infile_path.with_suffix(".xml")
 
+    if outfile_path.exists():
+        overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+        while overwrite not in {"y", "n", ""}:
+            overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+
+        if overwrite != "y":
+            print("Not overwriting output, nothing to do!")
+            return
+
     infile = open(infile_path, "rb")
     outfile = open(outfile_path, "wb")
 

--- a/examples/auto.py
+++ b/examples/auto.py
@@ -314,7 +314,7 @@ def main():
 
     infile_path: pathlib.Path = args.infile
     outfile_path: pathlib.Path = args.outfile
-    if outfile_path is None or not outfile_path.exists():
+    if outfile_path is None:
         outfile_path = infile_path.with_suffix(".xml")
 
     infile = open(infile_path, "rb")

--- a/examples/decode.py
+++ b/examples/decode.py
@@ -238,14 +238,14 @@ def main():
     if outfile_path is None:
         outfile_path = infile_path.with_suffix(".xml")
 
-    if outfile_path.exists():
-        overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
-        while overwrite not in {"y", "n", ""}:
+        if outfile_path.exists():
             overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+            while overwrite not in {"y", "n", ""}:
+                overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
 
-        if overwrite != "y":
-            print("Not overwriting output, nothing to do!")
-            return
+            if overwrite != "y":
+                print("Not overwriting output, nothing to do!")
+                return
 
     infile = open(infile_path, "rb")
     outfile = open(outfile_path, "wb")

--- a/examples/decode.py
+++ b/examples/decode.py
@@ -238,6 +238,15 @@ def main():
     if outfile_path is None:
         outfile_path = infile_path.with_suffix(".xml")
 
+    if outfile_path.exists():
+        overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+        while overwrite not in {"y", "n", ""}:
+            overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+
+        if overwrite != "y":
+            print("Not overwriting output, nothing to do!")
+            return
+
     infile = open(infile_path, "rb")
     outfile = open(outfile_path, "wb")
 

--- a/examples/decode.py
+++ b/examples/decode.py
@@ -235,7 +235,7 @@ def main():
 
     infile_path: pathlib.Path = args.infile
     outfile_path: pathlib.Path = args.outfile
-    if outfile_path is None or not outfile_path.exists():
+    if outfile_path is None:
         outfile_path = infile_path.with_suffix(".xml")
 
     infile = open(infile_path, "rb")

--- a/examples/encode.py
+++ b/examples/encode.py
@@ -124,7 +124,7 @@ def main():
 
     infile_path: pathlib.Path = args.infile
     outfile_path: pathlib.Path = args.outfile
-    if outfile_path is None or not outfile_path.exists():
+    if outfile_path is None:
         outfile_path = infile_path.with_suffix(".bin")
 
     infile = open(infile_path, "rb")

--- a/examples/encode.py
+++ b/examples/encode.py
@@ -127,6 +127,15 @@ def main():
     if outfile_path is None:
         outfile_path = infile_path.with_suffix(".bin")
 
+    if outfile_path.exists():
+        overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+        while overwrite not in {"y", "n", ""}:
+            overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+
+        if overwrite != "y":
+            print("Not overwriting output, nothing to do!")
+            return
+
     infile = open(infile_path, "rb")
     outfile = open(outfile_path, "wb")
 

--- a/examples/encode.py
+++ b/examples/encode.py
@@ -127,14 +127,14 @@ def main():
     if outfile_path is None:
         outfile_path = infile_path.with_suffix(".bin")
 
-    if outfile_path.exists():
-        overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
-        while overwrite not in {"y", "n", ""}:
+        if outfile_path.exists():
             overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+            while overwrite not in {"y", "n", ""}:
+                overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
 
-        if overwrite != "y":
-            print("Not overwriting output, nothing to do!")
-            return
+            if overwrite != "y":
+                print("Not overwriting output, nothing to do!")
+                return
 
     infile = open(infile_path, "rb")
     outfile = open(outfile_path, "wb")

--- a/examples/just_compress.py
+++ b/examples/just_compress.py
@@ -24,8 +24,8 @@ def main():
 
     infile_path: pathlib.Path = args.infile
     outfile_path: pathlib.Path = args.outfile
-    if outfile_path is None or not outfile_path.exists():
         outfile_path = infile_path.with_suffix(".xml")
+    if outfile_path is None:
 
     infile = open(infile_path, "rb")
     outfile = open(outfile_path, "wb")

--- a/examples/just_compress.py
+++ b/examples/just_compress.py
@@ -24,8 +24,8 @@ def main():
 
     infile_path: pathlib.Path = args.infile
     outfile_path: pathlib.Path = args.outfile
-        outfile_path = infile_path.with_suffix(".xml")
     if outfile_path is None:
+        outfile_path = infile_path.with_suffix(".zlib")
 
     if outfile_path.exists():
         overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()

--- a/examples/just_compress.py
+++ b/examples/just_compress.py
@@ -27,6 +27,15 @@ def main():
         outfile_path = infile_path.with_suffix(".xml")
     if outfile_path is None:
 
+    if outfile_path.exists():
+        overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+        while overwrite not in {"y", "n", ""}:
+            overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+
+        if overwrite != "y":
+            print("Not overwriting output, nothing to do!")
+            return
+
     infile = open(infile_path, "rb")
     outfile = open(outfile_path, "wb")
 

--- a/examples/just_compress.py
+++ b/examples/just_compress.py
@@ -27,14 +27,14 @@ def main():
     if outfile_path is None:
         outfile_path = infile_path.with_suffix(".zlib")
 
-    if outfile_path.exists():
-        overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
-        while overwrite not in {"y", "n", ""}:
+        if outfile_path.exists():
             overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+            while overwrite not in {"y", "n", ""}:
+                overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
 
-        if overwrite != "y":
-            print("Not overwriting output, nothing to do!")
-            return
+            if overwrite != "y":
+                print("Not overwriting output, nothing to do!")
+                return
 
     infile = open(infile_path, "rb")
     outfile = open(outfile_path, "wb")

--- a/examples/just_decrypt.py
+++ b/examples/just_decrypt.py
@@ -28,8 +28,8 @@ def main():
 
     infile_path: pathlib.Path = args.infile
     outfile_path: pathlib.Path = args.outfile
-        outfile_path = infile_path.with_suffix(".xml")
     if outfile_path is None:
+        outfile_path = infile_path.with_suffix(".zlib")
 
     if outfile_path.exists():
         overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()

--- a/examples/just_decrypt.py
+++ b/examples/just_decrypt.py
@@ -31,6 +31,15 @@ def main():
         outfile_path = infile_path.with_suffix(".xml")
     if outfile_path is None:
 
+    if outfile_path.exists():
+        overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+        while overwrite not in {"y", "n", ""}:
+            overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+
+        if overwrite != "y":
+            print("Not overwriting output, nothing to do!")
+            return
+
     infile = open(infile_path, "rb")
     outfile = open(outfile_path, "wb")
 

--- a/examples/just_decrypt.py
+++ b/examples/just_decrypt.py
@@ -31,14 +31,14 @@ def main():
     if outfile_path is None:
         outfile_path = infile_path.with_suffix(".zlib")
 
-    if outfile_path.exists():
-        overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
-        while overwrite not in {"y", "n", ""}:
+        if outfile_path.exists():
             overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
+            while overwrite not in {"y", "n", ""}:
+                overwrite = input(f"Output file {outfile_path} exists, overwrite? (y/N) ").lower()
 
-        if overwrite != "y":
-            print("Not overwriting output, nothing to do!")
-            return
+            if overwrite != "y":
+                print("Not overwriting output, nothing to do!")
+                return
 
     infile = open(infile_path, "rb")
     outfile = open(outfile_path, "wb")

--- a/examples/just_decrypt.py
+++ b/examples/just_decrypt.py
@@ -28,8 +28,8 @@ def main():
 
     infile_path: pathlib.Path = args.infile
     outfile_path: pathlib.Path = args.outfile
-    if outfile_path is None or not outfile_path.exists():
         outfile_path = infile_path.with_suffix(".xml")
+    if outfile_path is None:
 
     infile = open(infile_path, "rb")
     outfile = open(outfile_path, "wb")


### PR DESCRIPTION
Prior to these commits if the output file specified during invocation didn't exist, the example scripts wouldn't simply create it. Instead, it would write to a file in the same path as the input file, changing the extension. This has the potential of overwriting user files, eg the original configuration. This PR changes that by requesting confirmation before overwriting the output file if it already exists. Note that this doesn't address race conditions, eg some other process creating and writing to the same path as the output file between checking if the output exists and actually opening it.

Also, this fixes the default output file extension in examples/just_decrypt.py and examples/just_compress.py